### PR TITLE
Improvement to genGradleProjects task

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
@@ -632,6 +632,8 @@ public class PatcherPlugin extends BasePlugin<PatcherExtension> {
         Version version = parseAndStoreVersion(versionJson, versionJson.getParentFile(), delayedFile(Constants.DIR_JSONS).call());
 
         TaskGenSubprojects createProjects = (TaskGenSubprojects) project.getTasks().getByName(TASK_GEN_PROJECTS);
+        createProjects.getInputs().file(versionJson);
+
         Set<String> repos = Sets.newHashSet();
 
         for (Library lib : version.getLibraries()) {


### PR DESCRIPTION
genGradleProjects task will now rerun after changing version json, this previously required deleting the build.gradle in projects directory.