### PR TITLE
Continue applying extra transformers when reobfuscating even if an exception is thrown by a transformer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,8 +76,7 @@ dependencies {
     implementation 'com.github.tony19:named-regexp:0.2.3' // 1.7 Named regexp features
     implementation 'net.minecraftforge:fernflower:2.0-SNAPSHOT' // Fernflower Forge edition
 
-    shade 'net.md-5:SpecialSource:1.7.4' // deobf and reobs
-    // compile 'net.md-5:SpecialSource:1.7.4' // when md5 publishes
+    shade 'com.github.UserTeemu:SpecialSource:1.7.4-SNAPSHOT' // deobf and reobs
 
     // because curse
     implementation 'org.apache.httpcomponents:httpclient:4.3.3'

--- a/src/main/java/net/minecraftforge/gradle/user/TaskSingleReobf.java
+++ b/src/main/java/net/minecraftforge/gradle/user/TaskSingleReobf.java
@@ -232,7 +232,11 @@ public class TaskSingleReobf extends DefaultTask {
                 // correct source name
                 if (e.getName().endsWith(".class")) {
                     for (ReobfTransformer trans : transformers) {
-                        data = trans.transform(data);
+                        try {
+                            data = trans.transform(data);
+                        } catch (Exception exception) {
+                            getLogger().warn("Failed to transform class "+e.getName()+" using transformer "+trans.getClass().getName(), exception);
+                        }
                     }
                 }
 

--- a/src/main/java/net/minecraftforge/gradle/user/TaskSingleReobf.java
+++ b/src/main/java/net/minecraftforge/gradle/user/TaskSingleReobf.java
@@ -235,7 +235,7 @@ public class TaskSingleReobf extends DefaultTask {
                         try {
                             data = trans.transform(data);
                         } catch (Exception exception) {
-                            getLogger().warn("Failed to transform class "+e.getName()+" using transformer "+trans.getClass().getName(), exception);
+                            getLogger().warn("Failed to transform class {} using transformer {}", e.getName(), trans.getClass().getName(), exception);
                         }
                     }
                 }


### PR DESCRIPTION
Instead of completely stopping reobfuscating, this commit will just print a warning about it to the log and continue.

This allows for e.g. Kotlin 1.4 (and above) to be shaded into mods without ForgeGradle refusing to compile the final jar. The ASM version used by ForgeGradle's transformer cannot handle bytecode versions above 1.8 and will throw an exception. (BTW Forge (not ForgeGradle) will scream at the user a bit in the logs when running a mod that contains Kotlin 1.4, but the mod seems to work)

Is it ok to use `'com.github.UserTeemu:SpecialSource:1.7.4-SNAPSHOT'` as the fork, or do you want it to be a specific commit (can be [this commit](https://github.com/UserTeemu/SpecialSource/commit/f5cd6339d1c194afbb4f56450205ff165c05b246)), or do you want to fork it yourself for example?